### PR TITLE
Add standalone mptcpd plugin example.

### DIFF
--- a/examples/plugins/COPYING
+++ b/examples/plugins/COPYING
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Intel Corporation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/plugins/Makefile.am
+++ b/examples/plugins/Makefile.am
@@ -8,6 +8,6 @@ plugindir = @MPTCPD_PLUGINDIR@
 plugin_LTLIBRARIES = foo.la
 
 foo_la_SOURCES = foo.c
-foo_la_CFLAGS  = $(MPTCPD_PLUGIN_CFLAGS)
+foo_la_CFLAGS  = $(MPTCPD_CFLAGS)
 foo_la_LDFLAGS = -no-undefined -module -avoid-version
 foo_la_LIBADD  = $(MPTCPD_LIBS)

--- a/examples/plugins/Makefile.am
+++ b/examples/plugins/Makefile.am
@@ -1,0 +1,13 @@
+## SPDX-License-Identifier: BSD-3-Clause
+##
+## Copyright (c) 2019, Intel Corporation
+
+ACLOCAL_AMFLAGS = -I m4
+
+plugindir = @MPTCPD_PLUGINDIR@
+plugin_LTLIBRARIES = foo.la
+
+foo_la_SOURCES = foo.c
+foo_la_CFLAGS  = $(MPTCPD_PLUGIN_CFLAGS)
+foo_la_LDFLAGS = -no-undefined -module -avoid-version
+foo_la_LIBADD  = $(MPTCPD_LIBS)

--- a/examples/plugins/bootstrap
+++ b/examples/plugins/bootstrap
@@ -1,0 +1,6 @@
+#! /bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2019, Intel Corporation
+
+autoreconf --install --symlink --force

--- a/examples/plugins/configure.ac
+++ b/examples/plugins/configure.ac
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+#
+# Copyright (c) 2019, Intel Corporation
+
+AC_PREREQ([2.69])
+AC_INIT([foo_plugin], [0.1])
+
+AM_INIT_AUTOMAKE([foreign])
+LT_INIT([disable-static])
+
+AC_CONFIG_SRCDIR([foo.c])
+AC_CONFIG_MACRO_DIRS([m4])
+
+# ---------------------------------------------------------------
+# Checks for programs.
+# ---------------------------------------------------------------
+AC_PROG_CC_STDC
+AM_PROG_CC_C_O
+
+# ---------------------------------------------------------------
+# Checks for libraries.
+# ---------------------------------------------------------------
+# Find mptcpd.
+PKG_CHECK_MODULES([MPTCPD], [mptcpd])
+
+# Determine default mptcpd plugin directory.
+PKG_CHECK_VAR([MPTCPD_PLUGINDIR], [mptcpd], [plugindir])
+
+# ---------------------------------------------------------------
+# Generate our build files.
+# ---------------------------------------------------------------
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/examples/plugins/foo.c
+++ b/examples/plugins/foo.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file foo.c
+ *
+ * @brief Sample mptcpd plugin.
+ *
+ * Copyright (c) 2019, Intel Corporation
+ */
+
+#include <ell/ell.h>
+#include <mptcpd/network_monitor.h>
+#include <mptcpd/path_manager.h>
+#include <mptcpd/plugin.h>
+
+#define PLUGIN_NAME foo
+
+static void foo_new_connection(mptcpd_token_t token,
+                               struct sockaddr const *laddr,
+                               struct sockaddr const *raddr,
+                               struct mptcpd_pm *pm)
+{
+    // Handle creation of new MPTCP connection.
+}
+
+static void foo_connection_established(
+    mptcpd_token_t token,
+    struct sockaddr const *laddr,
+    struct sockaddr const *raddr,
+    struct mptcpd_pm *pm)
+{
+    // Handle establishment of new MPTCP connection.
+}
+
+static void foo_connection_closed(mptcpd_token_t token,
+                                  struct mptcpd_pm *pm)
+{
+    // Handle MPTCP connection closure.
+}
+
+static void foo_new_address(mptcpd_token_t token,
+                            mptcpd_aid_t addr_id,
+                            struct sockaddr const *addr,
+                            struct mptcpd_pm *pm)
+{
+    // Handle address advertised by MPTCP capable peer.
+}
+
+static void foo_address_removed(mptcpd_token_t token,
+                                mptcpd_aid_t addr_id,
+                                struct mptcpd_pm *pm)
+{
+    // Handle address no longer advertised by MPTCP capable peer.
+}
+
+static void foo_new_subflow(mptcpd_token_t token,
+                            struct sockaddr const *laddr,
+                            struct sockaddr const *raddr,
+                            bool backup,
+                            struct mptcpd_pm *pm)
+{
+    // Handle new subflow added to the MPTCP connection.
+}
+
+static void foo_subflow_closed(mptcpd_token_t token,
+                               struct sockaddr const *laddr,
+                               struct sockaddr const *raddr,
+                               bool backup,
+                               struct mptcpd_pm *pm)
+{
+    // Handle MPTCP subflow closure.
+}
+
+static void foo_subflow_priority(mptcpd_token_t token,
+                                 struct sockaddr const *laddr,
+                                 struct sockaddr const *raddr,
+                                 bool backup,
+                                 struct mptcpd_pm *pm)
+{
+    // Handle change in MPTCP subflow priority.
+}
+
+static struct mptcpd_plugin_ops const pm_ops = {
+    .new_connection         = foo_new_connection,
+    .connection_established = foo_connection_established,
+    .connection_closed      = foo_connection_closed,
+    .new_address            = foo_new_address,
+    .address_removed        = foo_address_removed,
+    .new_subflow            = foo_new_subflow,
+    .subflow_closed         = foo_subflow_closed,
+    .subflow_priority       = foo_subflow_priority
+};
+
+static int foo_init(void)
+{
+    static char const name[] = L_STRINGIFY(PLUGIN_NAME);
+
+    if (!mptcpd_plugin_register_ops(name, &pm_ops)) {
+        l_error("Failed to initialize plugin '%s'.", name);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+static void foo_exit(void)
+{
+}
+
+L_PLUGIN_DEFINE(MPTCPD_PLUGIN_DESC,
+                PLUGIN_NAME,
+                "foo path management plugin",
+                VERSION,
+                L_PLUGIN_PRIORITY_DEFAULT,
+                foo_init,
+                foo_exit)

--- a/examples/plugins/m4/.gitignore
+++ b/examples/plugins/m4/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except these files
+!.gitignore

--- a/lib/mptcpd.pc.in
+++ b/lib/mptcpd.pc.in
@@ -4,13 +4,13 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-# Mptcpd package library directory.
+# Mptcpd plugin directory.
 #
 # This corresponds to the default plugin directory set when mptcpd was
 # built.  It may differ from the actual site-specific plugin directory
 # if the default directory was overridden in the mptcpd configuration
 # file or on the command line.
-pkglibdir=@libdir@/@PACKAGE@
+plugindir=@libdir@/@PACKAGE@
 
 # Package keywords.
 Name: @PACKAGE_NAME@

--- a/plugins/path_managers/Makefile.am
+++ b/plugins/path_managers/Makefile.am
@@ -4,22 +4,17 @@
 
 include $(top_srcdir)/aminclude_static.am
 
-MPTCPD_PLUGIN_CPPFLAGS = \
-	-I$(top_srcdir)/include
-
 pkglib_LTLIBRARIES = sspi.la
 
 sspi_la_SOURCES  = sspi.c
-sspi_la_CPPFLAGS = $(MPTCPD_PLUGIN_CPPFLAGS) $(CODE_COVERAGE_CPPFLAGS)
+sspi_la_CPPFLAGS = -I$(top_srcdir)/include $(CODE_COVERAGE_CPPFLAGS)
 sspi_la_CFLAGS   = 		\
 	$(ELL_CFLAGS)		\
-	$(MPTCPD_PLUGIN_CFLAGS)	\
 	$(CODE_COVERAGE_CFLAGS)
 sspi_la_LDFLAGS  =       \
 	-no-undefined    \
 	-module          \
-	-avoid-version   \
-        $(ELL_LIBS)
+	-avoid-version
 sspi_la_LIBADD   =                       \
         $(top_builddir)/lib/libmptcpd.la \
         $(CODE_COVERAGE_LIBS)


### PR DESCRIPTION
Add a standalone (out-of-tree) mptcpd no-op plugin example to be used as a reference for mptcpd plugin developers.
