### PR TITLE
configuration: Fix {addr,notify} flag debug log.

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -139,20 +139,21 @@ static char const *flags_string(struct tok_entry const *toks,
                                 char *str,
                                 size_t len)
 {
-        struct tok_entry const *tok;
         char const *sep= "";
 
         char *tmp = str;
         tmp[0] = 0;
-        for (tok = toks; tok->id; tok++) {
+
+        for (struct tok_entry const *tok = toks; tok->id; tok++) {
                if (flags & tok->id) {
-                       size_t ret =
+                       size_t const ret =
                                append_tok(tmp, len, sep, tok->string);
                        tmp += ret;
                        len -= ret;
                        sep = ",";
                }
         }
+
         return str;
 }
 


### PR DESCRIPTION
Correct logic in the flags_string() function that returns the
stringified form of the addr and notify flags in the mptcpd
configuration.  The end of the flags string was returned rather than
the beginning, resulting in empty debug log messages for those
strings.