### PR TITLE
mptcpize: force MPTCP usage for IPPROTO_IP, too

### DIFF
--- a/src/mptcpwrap.c
+++ b/src/mptcpwrap.c
@@ -27,7 +27,7 @@ int __attribute__((visibility("default"))) socket(int family, int type, int prot
 		goto do_socket;
 
 	// socket(AF_INET, SOCK_STREM, 0) maps to TCP, too
-	if (protocol == 0 && protocol != IPPROTO_TCP)
+	if (protocol != 0 && protocol != IPPROTO_TCP)
 		goto do_socket;
 
 	protocol = IPPROTO_TCP + 256;


### PR DESCRIPTION
The current ignores calls alike:

	socket(AF_INET, SOCK_STREAM, IPPROTO_IP)

We should hijack them, too.