### PR TITLE
github: Add systemd service start/stop check.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -41,5 +41,12 @@ jobs:
       run: sudo make install
     - name: make installcheck
       run: LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH make installcheck
+    - name: systemd check
+      run: |
+        sudo systemctl daemon-reload
+        systemd-analyze --no-pager verify   mptcp.service
+        systemd-analyze --no-pager security mptcp.service
+        sudo systemctl start mptcp.service
+        sudo systemctl stop  mptcp.service
     - name: make uninstall
       run: sudo make uninstall


### PR DESCRIPTION
Add a step to the mptcpd "C/C++ CI" GitHub workflow that verifies
mptcpd successfully starts and stop through systemd using the
mptcp.service unit file generated during the build.