### PR TITLE
etc: Add Debian init.d script for mptcpd.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ mptcpd-*/
 core*
 doc/
 etc/*.conf
+etc/init.d/mptcpd
 lib/mptcpd.pc
 src/mptcpd
 src/mptcpize

--- a/configure.ac
+++ b/configure.ac
@@ -369,6 +369,7 @@ AC_SUBST([TEST_PLUGIN_NOOP],  [plugin_noop])
 # ---------------------------------------------------------------
 AC_CONFIG_FILES([Makefile
                  etc/Makefile
+                 etc/init.d/Makefile
                  man/Makefile
                  include/Makefile
                  include/linux/Makefile

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,6 +1,8 @@
 ## SPDX-License-Identifier: BSD-3-Clause
 ##
-## Copyright (c) 2018, 2019, Intel Corporation
+## Copyright (c) 2018, 2019, 2022, Intel Corporation
+
+SUBDIRS = init.d
 
 EXTRA_DIST = mptcpd.conf.in
 

--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -1,0 +1,37 @@
+## SPDX-License-Identifier: BSD-3-Clause
+##
+## Copyright (c) 2022, Intel Corporation
+
+EXTRA_DIST = mptcpd.in
+
+initddir = $(sysconfdir)/init.d
+initd_SCRIPTS = mptcpd
+
+## The configure script won't fully expand variables like $libexecdir
+## so leverage `make' based variable expansion instead.
+if HAVE_SYSTEMD
+mptcpdbindir = @libexecdir@
+else
+mptcpdbindir = @bindir@
+endif
+
+mptcpd: Makefile mptcpd.in
+	$(AM_V_GEN)rm -f $@ $@.tmp; \
+	srcdir=''; \
+		test -f ./$@.in || srcdir=$(srcdir)/; \
+		sed \
+			-e 's,@libdir[@],$(libdir),g' \
+			-e 's,@mptcpdbindir[@],$(mptcpdbindir),g' \
+			$${srcdir}$@.in >$@.tmp; \
+	chmod 755 $@.tmp; \
+	mv $@.tmp $@
+
+CLEANFILES = mptcpd
+
+# Make sure the system init.d directory is not world writable.
+install-data-hook: installcheck-local
+	chmod o-w $(DESTDIR)$(initddir)
+
+installcheck-local:
+	$(top_srcdir)/scripts/check-permissions \
+		$(DESTDIR)$(initddir)

--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -34,4 +34,5 @@ install-data-hook: installcheck-local
 
 installcheck-local:
 	$(top_srcdir)/scripts/check-permissions \
-		$(DESTDIR)$(initddir)
+		$(DESTDIR)$(initddir) \
+		$(DESTDIR)$(initddir)/mptcpd

--- a/etc/init.d/Makefile.am
+++ b/etc/init.d/Makefile.am
@@ -28,6 +28,8 @@ mptcpd: Makefile mptcpd.in
 
 CLEANFILES = mptcpd
 
+AM_INSTALLCHECK_STD_OPTIONS_EXEMPT = $(initd_SCRIPTS)
+
 # Make sure the system init.d directory is not world writable.
 install-data-hook: installcheck-local
 	chmod o-w $(DESTDIR)$(initddir)

--- a/etc/init.d/mptcpd.in
+++ b/etc/init.d/mptcpd.in
@@ -1,0 +1,22 @@
+#!/usr/bin/env /lib/init/init-d-script
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) 2022, Intel Corporation
+
+### BEGIN INIT INFO
+# Provides:          mptcpd
+# Required-Start:    $syslog $network $remote_fs
+# Required-Stop:     $syslog $network $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: run mptcpd
+# Description:       Debian init script to start the Multipath TCP daemon.
+### END INIT INFO
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:@libdir@
+export LD_LIBRARY_PATH
+
+DAEMON="@mptcpdbindir@/mptcpd"
+DAEMON_ARGS="--log=syslog"
+DESC="Multipath TCP Daemon"
+START_ARGS="--background --make-pidfile"


### PR DESCRIPTION
Add a Debian init.d script for mptcpd for the case where start of
mptcpd through systemd is not available or undesirable.