### PR TITLE
tests: fix segfault with no /etc/protocols

### DIFF
--- a/tests/mptcpwrap-tester.c
+++ b/tests/mptcpwrap-tester.c
@@ -64,7 +64,7 @@ static void test_socket_data(struct socket_data const *data)
                                 "WARNING: Ignoring unsupported "
                                 "protocol: %d - %s\n",
                                 data->protocol,
-                                p->p_name);
+                                p ? p->p_name : "Unknown");
 
                         return;
                 }


### PR DESCRIPTION
This file could be missing, which will cause getprotobynumber() to return NULL.

The returned pointer is used to mention the protocol name in a warning message, not critical. Instead, we can simply display 'Unknown' next to the protocol ID.

Fixes: d6a48d4 ("tests: Expand mptcpwrap code coverage. (#169)")
Reported-by: Aurelien Jarno @aurel32
Closes: https://bugs.debian.org/1060285