### PR TITLE
Update branch references

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,9 +2,9 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/ell-master.yml
+++ b/.github/workflows/ell-master.yml
@@ -2,9 +2,9 @@ name: ELL master
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/multipath-tcp.org.yml
+++ b/.github/workflows/multipath-tcp.org.yml
@@ -2,9 +2,9 @@ name: multipath-tcp.org kernel
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
      Copyright (c) 2017-2021, Intel Corporation -->
 
 [![C/C++ CI](https://github.com/multipath-tcp/mptcpd/actions/workflows/ccpp.yml/badge.svg)](https://github.com/multipath-tcp/mptcpd/actions/workflows/ccpp.yml)
-[![Coverage Status](https://coveralls.io/repos/github/multipath-tcp/mptcpd/badge.svg?branch=master)](https://coveralls.io/github/multipath-tcp/mptcpd?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/multipath-tcp/mptcpd/badge.svg?branch=main)](https://coveralls.io/github/multipath-tcp/mptcpd?branch=main)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 # Multipath TCP Daemon


### PR DESCRIPTION
The default branch name is now 'main' (see #289), so the Coveralls badge URLs and Github actions need to reference that branch name.