### PR TITLE
Perhaps a more correct calculation sizeof for memcpy()

### DIFF
--- a/lib/hash_sockaddr.c
+++ b/lib/hash_sockaddr.c
@@ -96,11 +96,11 @@ void *mptcpd_hash_sockaddr_key_copy(void const *p)
         if (src->sa->sa_family == AF_INET) {
                 sa = (struct sockaddr *) l_new(struct sockaddr_in, 1);
 
-                memcpy(sa, src->sa, sizeof(struct sockaddr_in));
+                memcpy(sa, src->sa, sizeof(*src->sa));
         } else {
                 sa = (struct sockaddr *) l_new(struct sockaddr_in6, 1);
 
-                memcpy(sa, src->sa, sizeof(struct sockaddr_in6));
+                memcpy(sa, src->sa, sizeof(*src->sa));
         }
 
         key->sa = sa;


### PR DESCRIPTION
@matttbe, @mjmartineau,

am I correct in assuming that in this code, memcpy has different size and it possible underflow or overflow?

I don't know code perfectly, so I'm asking you. If I make a mistake, cancel PR changes.