### PR TITLE
Improve check_route address notification flag documentation

### DIFF
--- a/etc/mptcpd.conf.in
+++ b/etc/mptcpd.conf.in
@@ -59,10 +59,17 @@ path-manager=@mptcpd_default_pm@
 #   skip_loopback
 #     Ignore (do not notify) host (loopback) address updates
 #
+#   check_route
+#     Notify address only if a default route is available from such
+#     address and the related device. If the route check fails, it
+#     will be re-done after a little timeout, to allow e.g. DHCP to
+#     configure the host properly. Complex policy routing
+#     configuration may confuse or circumvent this check.
+#
 # These flags determine whether mptpcd plugins will be notified when
 # related addresses are updated.
 #
-# notify-flags=existing,skip_link_local,skip_loopback
+# notify-flags=existing,skip_link_local,skip_loopback,check_route
 
 # --------------------------
 # Plugins to load

--- a/man/mptcpd.8.in
+++ b/man/mptcpd.8.in
@@ -102,17 +102,17 @@ ignore (do not notify) host (loopback) address updates
 .RS
 .TP
 .I check_route
-notify address only if a default route is available from such
-address and the related device. If the route check fails, it will
-re-done after a little timeout, to allow .e.g. DHCP to configure the
-host properly. Complex Policy routing configuration may confuse or
+notify address only if a default route is available from such address
+and the related device. If the route check fails, it will be re-done
+after a little timeout, to allow e.g. DHCP to configure the host
+properly. Complex policy routing configuration may confuse or
 circumvent this check.
 .RE
 .P
 .RS
 These flags determine whether mptpcd plugins will be notified when
 related addresses are updated, e.g.
-.B --notify-flags=existing,skip_link_local,check_route
+.B --notify-flags=existing,skip_link_local,skip_loopback,check_route
 .RE
 
 .TP


### PR DESCRIPTION
Hello. This patch improves the check_route address notification flag documentation. I suppose there's a 70 column limit on the files I've modified so I've folllowed that limit. Let me know if the patch subject is not OK.