### PR TITLE
Support ELL 0.68 l_netlink_message API.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 #
-# Copyright (c) 2017-2023, Intel Corporation
+# Copyright (c) 2017-2024, Intel Corporation
 
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,12 @@ AC_CHECK_FUNC([l_hashmap_replace],
               [AC_DEFINE([HAVE_L_HASHMAP_REPLACE],
                          [],
                          [ELL has l_hashmap_replace()])])
+
+dnl l_netlink_message_new_sized() was introduced in ELL v0.68.
+AC_CHECK_FUNC([l_netlink_message_new_sized],
+              [AC_DEFINE([HAVE_L_NETLINK_MESSAGE_NEW_SIZED],
+                         [],
+                         [ELL has l_netlink_message_new_sized()])])
 LIBS=$mptcpd_save_libs
 
 # ---------------------------------------------------------------

--- a/lib/network_monitor.c
+++ b/lib/network_monitor.c
@@ -1015,14 +1015,36 @@ static void check_default_route(struct nm_addr_info *ai)
          */
         mptcpd_addr_get(ai);
 
-        if (l_netlink_send(ai->nm->rtnl,
-                           RTM_GETROUTE,
-                           0,
-                           &store,
-                           buf - (char *) &store,
-                           handle_rtm_getroute,
-                           ai,
-                           NULL) == 0) {
+	unsigned int result = 0;
+
+#ifdef HAVE_L_NETLINK_MESSAGE_NEW_SIZED
+	// ELL >= 0.68
+        ptrdiff_t const msg_size = buf - (char *) &store;
+        struct l_netlink_message *const nlm =
+                l_netlink_message_new_sized(RTM_GETROUTE,
+                                            0,
+                                            msg_size);
+
+        l_netlink_message_add_header(nlm, &store, msg_size);
+
+	result = l_netlink_send(ai->nm->rtnl,
+				nlm,
+				handle_rtm_getroute,
+				ai,
+				NULL);
+#else
+	// ELL < 0.68
+	result = l_netlink_send(ai->nm->rtnl,
+				RTM_GETROUTE,
+				0,
+				&store,
+				buf - (char *) &store,
+				handle_rtm_getroute,
+				ai,
+				NULL);
+#endif
+
+        if (result == 0) {
                 l_debug("Route lookup failed");
                 mptcpd_addr_put(ai);
         }
@@ -1388,14 +1410,36 @@ static void send_getaddr_command(void *user_data)
 
         // Get IP addresses.
         struct ifaddrmsg addr_msg = { .ifa_family = AF_UNSPEC };
-        if (l_netlink_send(nm->rtnl,
-                           RTM_GETADDR,
-                           NLM_F_DUMP,
-                           &addr_msg,
-                           sizeof(addr_msg),
-                           handle_rtm_getaddr,
-                           nm,
-                           NULL) == 0) {
+
+	unsigned int result = 0;
+
+#ifdef HAVE_L_NETLINK_MESSAGE_NEW_SIZED
+	// ELL >= 0.68
+        struct l_netlink_message *const nlm =
+                l_netlink_message_new_sized(RTM_GETADDR,
+                                            NLM_F_DUMP,
+                                            sizeof(addr_msg));
+
+        l_netlink_message_add_header(nlm, &addr_msg, sizeof(addr_msg));
+
+	result = l_netlink_send(nm->rtnl,
+				nlm,
+				handle_rtm_getaddr,
+				nm,
+				NULL);
+#else
+	// ELL < 0.68
+	result = l_netlink_send(nm->rtnl,
+				RTM_GETADDR,
+				NLM_F_DUMP,
+				&addr_msg,
+				sizeof(addr_msg),
+				handle_rtm_getaddr,
+				nm,
+				NULL);
+#endif
+
+	if (result == 0) {
                 l_error("Unable to obtain IP addresses.");
 
                 /*
@@ -1481,15 +1525,36 @@ struct mptcpd_nm *mptcpd_nm_create(uint32_t flags)
          *       resulted in an EBUSY error.
          */
         struct ifinfomsg link_msg = { .ifi_family = AF_UNSPEC };
-        if (l_netlink_send(nm->rtnl,
-                           RTM_GETLINK,
-                           NLM_F_DUMP,
-                           &link_msg,
-                           sizeof(link_msg),
-                           handle_rtm_getlink,
-                           nm,
-                           send_getaddr_command)
-            == 0) {
+
+	unsigned int result = 0;
+
+#ifdef HAVE_L_NETLINK_MESSAGE_NEW_SIZED
+	// ELL >= 0.68
+        struct l_netlink_message *const nlm =
+                l_netlink_message_new_sized(RTM_GETLINK,
+                                            NLM_F_DUMP,
+                                            sizeof(link_msg));
+
+        l_netlink_message_add_header(nlm, &link_msg, sizeof(link_msg));
+
+        result = l_netlink_send(nm->rtnl,
+				nlm,
+				handle_rtm_getlink,
+				nm,
+				send_getaddr_command);
+#else
+	// ELL < 0.68
+	result = l_netlink_send(nm->rtnl,
+				RTM_GETLINK,
+				NLM_F_DUMP,
+				&link_msg,
+				sizeof(link_msg),
+				handle_rtm_getlink,
+				nm,
+				send_getaddr_command);
+#endif
+
+        if (result == 0) {
                 l_error("Unable to obtain network devices.");
                 mptcpd_nm_destroy(nm);
                 return NULL;


### PR DESCRIPTION
ELL 0.68 introduced a non-backward compatible change to its API by introducing a new `l_netlink_message` API to simplify use of the `l_netlink_send()` function.   Support both the pre- and post- ELL 0.68 versions of the `l_netlink_send()` function.

Fixes #299.