### PR TITLE
Support listener events

### DIFF
--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -263,6 +263,26 @@ struct mptcpd_plugin_ops
                                  struct sockaddr const *raddr,
                                  bool backup,
                                  struct mptcpd_pm *pm);
+
+        /**
+         * @brief New MPTCP listener socket has been created.
+         *
+         * @param[in] laddr       Local address information.
+         * @param[in] pm          Opaque pointer to mptcpd path
+         *                        manager object.
+         */
+        void (*listener_created)(struct sockaddr const *laddr,
+                                 struct mptcpd_pm *pm);
+
+        /**
+         * @brief MPTCP listener socket has been closed.
+         *
+         * @param[in] laddr       Local address information.
+         * @param[in] pm          Opaque pointer to mptcpd path
+         *                        manager object.
+         */
+        void (*listener_closed)(struct sockaddr const *laddr,
+                                struct mptcpd_pm *pm);
         ///@}
 
         // --------------------------------------------------------

--- a/include/mptcpd/private/plugin.h
+++ b/include/mptcpd/private/plugin.h
@@ -167,6 +167,28 @@ MPTCPD_API void mptcpd_plugin_subflow_priority(
         struct sockaddr const *raddr,
         bool backup,
         struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of MPTCP listener creation.
+ *
+ * @param[in] laddr  Local address information.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_listener_created(
+        char const *name,
+        struct sockaddr const *laddr,
+        struct mptcpd_pm *pm);
+
+/**
+ * @brief Notify plugin of MPTCP listener closure.
+ *
+ * @param[in] laddr  Local address information.
+ * @param[in] pm     Opaque pointer to mptcpd path manager object.
+ */
+MPTCPD_API void mptcpd_plugin_listener_closed(
+        char const *name,
+        struct sockaddr const *laddr,
+        struct mptcpd_pm *pm);
 ///@}
 
 /**

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -679,6 +679,28 @@ void mptcpd_plugin_subflow_priority(mptcpd_token_t token,
 
 }
 
+void mptcpd_plugin_listener_created(char const *name,
+                                    struct sockaddr const *laddr,
+                                    struct mptcpd_pm *pm)
+{
+        struct mptcpd_plugin_ops const *const ops = name_to_ops(name);
+
+        if (ops && ops->listener_created)
+                ops->listener_created(laddr, pm);
+
+}
+
+void mptcpd_plugin_listener_closed(char const *name,
+                                   struct sockaddr const *laddr,
+                                   struct mptcpd_pm *pm)
+{
+        struct mptcpd_plugin_ops const *const ops = name_to_ops(name);
+
+        if (ops && ops->listener_closed)
+                ops->listener_closed(laddr, pm);
+
+}
+
 // ----------------------------------------------------------------
 // Network Monitoring Related Plugin Operation Callback Invocation
 // ----------------------------------------------------------------

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -781,6 +781,29 @@ static void sspi_subflow_priority(mptcpd_token_t token,
         */
 }
 
+static void sspi_listener_created(struct sockaddr const *laddr,
+                                  struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+
+        /*
+          The sspi plugin doesn't do anything with newly created listener
+          sockets.
+        */
+}
+
+static void sspi_listener_closed(struct sockaddr const *laddr,
+                                 struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+
+        /*
+          The sspi plugin doesn't do anything with closed listener sockets.
+        */
+}
+
 static struct mptcpd_plugin_ops const pm_ops = {
         .new_connection         = sspi_new_connection,
         .connection_established = sspi_connection_established,
@@ -789,7 +812,9 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .address_removed        = sspi_address_removed,
         .new_subflow            = sspi_new_subflow,
         .subflow_closed         = sspi_subflow_closed,
-        .subflow_priority       = sspi_subflow_priority
+        .subflow_priority       = sspi_subflow_priority,
+        .listener_created       = sspi_listener_created,
+        .listener_closed        = sspi_listener_closed
 };
 
 static int sspi_init(struct mptcpd_pm *pm)

--- a/tests/lib/call_count.c
+++ b/tests/lib/call_count.c
@@ -22,6 +22,8 @@ void call_count_reset(struct plugin_call_count *p)
         p->new_subflow            = 0;
         p->subflow_closed         = 0;
         p->subflow_priority       = 0;
+        p->listener_created       = 0;
+        p->listener_closed        = 0;
         p->new_interface          = 0;
         p->update_interface       = 0;
         p->delete_interface       = 0;
@@ -39,6 +41,8 @@ bool call_count_all_positive(struct plugin_call_count const *p)
                 && p->new_subflow            >= 0
                 && p->subflow_closed         >= 0
                 && p->subflow_priority       >= 0
+                && p->listener_created       >= 0
+                && p->listener_closed        >= 0
                 && p->new_interface          >= 0
                 && p->update_interface       >= 0
                 && p->delete_interface       >= 0
@@ -71,6 +75,8 @@ bool call_count_is_equal(struct plugin_call_count const *lhs,
             && lhs->new_subflow            == rhs->new_subflow
             && lhs->subflow_closed         == rhs->subflow_closed
             && lhs->subflow_priority       == rhs->subflow_priority
+            && lhs->listener_created       == rhs->listener_created
+            && lhs->listener_closed        == rhs->listener_closed
             && lhs->new_interface          == rhs->new_interface
             && lhs->update_interface       == rhs->update_interface
             && lhs->delete_interface       == rhs->delete_interface

--- a/tests/lib/call_plugin.c
+++ b/tests/lib/call_plugin.c
@@ -70,6 +70,16 @@ void call_plugin_ops(struct plugin_call_count const *count,
                                                args->backup,
                                                args->pm);
 
+        for (int i = 0; i < count->listener_created; ++i)
+                mptcpd_plugin_listener_created(args->name,
+                                               args->laddr,
+                                               args->pm);
+
+        for (int i = 0; i < count->listener_closed; ++i)
+                mptcpd_plugin_listener_closed(args->name,
+                                              args->laddr,
+                                              args->pm);
+
         for (int i = 0; i < count->connection_closed; ++i)
                 mptcpd_plugin_connection_closed(args->token, args->pm);
 

--- a/tests/lib/test-plugin.h
+++ b/tests/lib/test-plugin.h
@@ -99,7 +99,9 @@ static struct plugin_call_count const test_count_1 = {
         .address_removed        = 0,
         .new_subflow            = 0,
         .subflow_closed         = 0,
-        .subflow_priority       = 0
+        .subflow_priority       = 0,
+        .listener_created       = 1,
+        .listener_closed        = 1
 };
 
 static struct plugin_call_count const test_count_2 = {
@@ -111,6 +113,8 @@ static struct plugin_call_count const test_count_2 = {
         .new_subflow            = 1,
         .subflow_closed         = 1,
         .subflow_priority       = 1,
+        .listener_created       = 1,
+        .listener_closed        = 1,
         .new_interface          = 1,
         .update_interface       = 2,
         .delete_interface       = 1,
@@ -126,7 +130,9 @@ static struct plugin_call_count const test_count_4 = {
         .address_removed        = 1,
         .new_subflow            = 0,
         .subflow_closed         = 0,
-        .subflow_priority       = 0
+        .subflow_priority       = 0,
+        .listener_created       = 0,
+        .listener_closed        = 0
 };
 ///@}
 

--- a/tests/lib/test-plugin.h
+++ b/tests/lib/test-plugin.h
@@ -50,6 +50,8 @@ struct plugin_call_count
         int new_subflow;
         int subflow_closed;
         int subflow_priority;
+        int listener_created;
+        int listener_closed;
         int new_interface;
         int update_interface;
         int delete_interface;

--- a/tests/plugins/noop/noop.c
+++ b/tests/plugins/noop/noop.c
@@ -113,6 +113,20 @@ static void plugin_noop_subflow_priority(mptcpd_token_t token,
         (void) pm;
 }
 
+static void plugin_noop_listener_created(struct sockaddr const *laddr,
+                                         struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+}
+
+static void plugin_noop_listener_closed(struct sockaddr const *laddr,
+                                        struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+}
+
 void plugin_noop_new_interface(struct mptcpd_interface const *i,
                                struct mptcpd_pm *pm)
 {
@@ -161,6 +175,8 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .new_subflow            = plugin_noop_new_subflow,
         .subflow_closed         = plugin_noop_subflow_closed,
         .subflow_priority       = plugin_noop_subflow_priority,
+        .listener_created       = plugin_noop_listener_created,
+        .listener_closed        = plugin_noop_listener_closed,
         .new_interface          = plugin_noop_new_interface,
         .update_interface       = plugin_noop_update_interface,
         .delete_interface       = plugin_noop_delete_interface,

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -158,6 +158,28 @@ static void plugin_one_subflow_priority(mptcpd_token_t token,
         ++call_count.subflow_priority;
 }
 
+static void plugin_one_listener_created(struct sockaddr const *laddr,
+                                        struct mptcpd_pm *pm)
+{
+        (void) pm;
+
+        assert(laddr != NULL);
+        assert(sockaddr_is_equal(laddr, local_addr));
+
+        ++call_count.listener_created;
+}
+
+static void plugin_one_listener_closed(struct sockaddr const *laddr,
+                                        struct mptcpd_pm *pm)
+{
+        (void) pm;
+
+        assert(laddr != NULL);
+        assert(sockaddr_is_equal(laddr, local_addr));
+
+        ++call_count.listener_closed;
+}
+
 static struct mptcpd_plugin_ops const pm_ops = {
         .new_connection         = plugin_one_new_connection,
         .connection_established = plugin_one_connection_established,
@@ -166,7 +188,9 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .address_removed        = plugin_one_address_removed,
         .new_subflow            = plugin_one_new_subflow,
         .subflow_closed         = plugin_one_subflow_closed,
-        .subflow_priority       = plugin_one_subflow_priority
+        .subflow_priority       = plugin_one_subflow_priority,
+        .listener_created       = plugin_one_listener_created,
+        .listener_closed        = plugin_one_listener_closed
 };
 
 static int plugin_one_init(struct mptcpd_pm *pm)
@@ -204,6 +228,8 @@ static void plugin_one_exit(struct mptcpd_pm *pm)
                 .new_subflow       = test_count_1.new_subflow       * 2,
                 .subflow_closed    = test_count_1.subflow_closed    * 2,
                 .subflow_priority  = test_count_1.subflow_priority  * 2,
+                .listener_created  = test_count_1.listener_created  * 2,
+                .listener_closed   = test_count_1.listener_closed   * 2,
         };
 
         assert(call_count_is_sane(&call_count));

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -160,6 +160,28 @@ static void plugin_two_subflow_priority(mptcpd_token_t token,
         ++call_count.subflow_priority;
 }
 
+static void plugin_two_listener_created(struct sockaddr const *laddr,
+                                        struct mptcpd_pm *pm)
+{
+        (void) pm;
+
+        assert(laddr != NULL);
+        assert(sockaddr_is_equal(laddr, local_addr));
+
+        ++call_count.listener_created;
+}
+
+static void plugin_two_listener_closed(struct sockaddr const *laddr,
+                                        struct mptcpd_pm *pm)
+{
+        (void) pm;
+
+        assert(laddr != NULL);
+        assert(sockaddr_is_equal(laddr, local_addr));
+
+        ++call_count.listener_closed;
+}
+
 void plugin_two_new_interface(struct mptcpd_interface const *i,
                               struct mptcpd_pm *pm)
 {
@@ -218,6 +240,8 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .new_subflow            = plugin_two_new_subflow,
         .subflow_closed         = plugin_two_subflow_closed,
         .subflow_priority       = plugin_two_subflow_priority,
+        .listener_created       = plugin_two_listener_created,
+        .listener_closed        = plugin_two_listener_closed,
         .new_interface          = plugin_two_new_interface,
         .update_interface       = plugin_two_update_interface,
         .delete_interface       = plugin_two_delete_interface,

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -140,6 +140,24 @@ static void plugin_four_subflow_priority(mptcpd_token_t token,
         ++call_count.subflow_priority;
 }
 
+static void plugin_four_listener_created(struct sockaddr const *laddr,
+                                         struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+
+        ++call_count.listener_created;
+}
+
+static void plugin_four_listener_closed(struct sockaddr const *laddr,
+                                        struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+
+        ++call_count.listener_closed;
+}
+
 static struct mptcpd_plugin_ops const pm_ops = {
         .new_connection         = plugin_four_new_connection,
         .connection_established = plugin_four_connection_established,
@@ -149,6 +167,8 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .new_subflow            = plugin_four_new_subflow,
         .subflow_closed         = plugin_four_subflow_closed,
         .subflow_priority       = plugin_four_subflow_priority,
+        .listener_created       = plugin_four_listener_created,
+        .listener_closed        = plugin_four_listener_closed,
 };
 
 static int plugin_four_init(struct mptcpd_pm *pm)

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -140,6 +140,24 @@ static void plugin_three_subflow_priority(mptcpd_token_t token,
         ++call_count.subflow_priority;
 }
 
+static void plugin_three_listener_created(struct sockaddr const *laddr,
+                                          struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+
+        ++call_count.listener_created;
+}
+
+static void plugin_three_listener_closed(struct sockaddr const *laddr,
+                                         struct mptcpd_pm *pm)
+{
+        (void) laddr;
+        (void) pm;
+
+        ++call_count.listener_closed;
+}
+
 static struct mptcpd_plugin_ops const pm_ops = {
         .new_connection         = plugin_three_new_connection,
         .connection_established = plugin_three_connection_established,
@@ -149,6 +167,8 @@ static struct mptcpd_plugin_ops const pm_ops = {
         .new_subflow            = plugin_three_new_subflow,
         .subflow_closed         = plugin_three_subflow_closed,
         .subflow_priority       = plugin_three_subflow_priority,
+        .listener_created       = plugin_three_listener_created,
+        .listener_closed        = plugin_three_listener_closed,
 };
 
 static int plugin_three_init(struct mptcpd_pm *pm)

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -311,6 +311,8 @@ static void test_null_plugin_ops(void const *test_data)
         mptcpd_plugin_new_subflow(token, laddr, raddr, backup, pm);
         mptcpd_plugin_subflow_closed(token, laddr, raddr, backup, pm);
         mptcpd_plugin_subflow_priority(token, laddr, raddr, backup, pm);
+        mptcpd_plugin_listener_created(name, laddr, pm);
+        mptcpd_plugin_listener_closed(name, laddr, pm);
         mptcpd_plugin_new_interface(interface, pm);
         mptcpd_plugin_update_interface(interface, pm);
         mptcpd_plugin_delete_interface(interface, pm);


### PR DESCRIPTION
These events have been added to the upstream kernel a while ago, see commit [f8c9dfbd875b](https://github.com/torvalds/linux/commit/f8c9dfbd875b1) ("mptcp: add pm listener events") in the kernel.

To better explain why these events are useful, better to quote the [feature request](https://github.com/multipath-tcp/mptcp_net-next/issues/313):

> MPTCP for Linux, when not using the in-kernel PM, depends on the userspace PM to create extra listening sockets before announcing addresses and ports. Let's call these "PM listeners".
>
> With the existing MPTCP netlink events, a userspace PM can create PM listeners at startup time, or in response to an incoming connection. Creating sockets in response to connections is not optimal: ADD_ADDRs can't be sent until the sockets are created and listen()ed, and if all connections are closed then it may not be clear to the userspace PM daemon that PM listener sockets should be cleaned up.
>
> With the addition of MPTCP netlink events for listening socket close & create, PM listening sockets can be managed based on application activity.

These new events are then now handled by mptcpd, and plugins can be notified via two new hooks:

- `listener_created(laddr, pm)`
- `listener_closed(laddr, pm)`

Note that without this PR, many entries are visible in the logs mentioning these events are not supported each time a new listener socket is created (maybe it would be better to display this warning only once, but that's a different issue):

```
Unhandled MPTCP event: 15
Unhandled MPTCP event: 16
```

Closes #284