### PR TITLE
lib: switch to v4.0.1: only added items

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,9 @@ AC_INIT([mptcpd],
 # Interfaces changed:  CURRENT++ REVISION=0
 #            added:    CURRENT++ REVISION=0 AGE++
 #            removed:  CURRENT++ REVISION=0 AGE=0
-LIB_CURRENT=3
+LIB_CURRENT=4
 LIB_REVISION=0
-LIB_AGE=0
+LIB_AGE=1
 
 AC_SUBST([LIB_CURRENT])
 AC_SUBST([LIB_REVISION])


### PR DESCRIPTION
The API has been modified: only new items have been added, see PR #297 and #304.

It is then required to increase CURRENT and AGE, according to libtool's documentation.