### PR TITLE
gh: daily validation of the ELL compatibility

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -16,7 +16,7 @@ jobs:
         debug: [enable-debug, disable-debug]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: sudo apt-get -y install autoconf-archive pandoc git
     - name: build and install ELL

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: sudo apt-get -y install autoconf-archive lcov git
     - name: build and install ELL

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
              CODE_COVERAGE_OUTPUT_FILE=lcov.info \
              CODE_COVERAGE_LCOV_OPTIONS="--no-external --exclude */tests/*"
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov.info
+        file: ./lcov.info

--- a/.github/workflows/ell-master.yml
+++ b/.github/workflows/ell-master.yml
@@ -18,7 +18,7 @@ jobs:
         cc: [gcc, clang]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: sudo apt-get -y install autoconf-archive git clang
     - name: build and install ELL

--- a/.github/workflows/ell-master.yml
+++ b/.github/workflows/ell-master.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '33 6 * * 1-5'
 
 jobs:
   build:

--- a/.github/workflows/multipath-tcp.org.yml
+++ b/.github/workflows/multipath-tcp.org.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dependencies
       run: sudo apt-get -y install autoconf-archive git
     - name: build and install ELL


### PR DESCRIPTION
We recently had some issues because the ELL API has been broken without notice.

Simply adding a cron to run the tests once a day during the week should tell us when an incompatible change has been introduced on ELL side, so we can get a bit of time to prepare a fix and a new release.

While at it, also switch to newer versions of some deprecated GH actions.