### PR TITLE
doc: describe the default behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ information (e.g. available remote addresses), available network
 interfaces, request new MPTCP subflows, handle requests for subflows,
 etc.
 
+## Behavior
 By default, this daemon will load the `addr_adv` plugin, which will
 add MPTCP endpoints with the `subflow` flag ("client" mode) for the
 default in-kernel path-manager. Note that this is something
@@ -27,6 +28,14 @@ when advanced per-connection path management is needed, using the
 userspace path-manager and a custom made
 [plugin](https://github.com/multipath-tcp/mptcpd/wiki/Plugins) using
 the [C API](https://mptcpd.mptcp.dev/doc/html/).
+
+To change this behavior, with NetworkManager, look for the
+`connection.mptcp-flags` option in the
+[settings](https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html#nm-settings-nmcli.property.connection.mptcp-flags),
+while for `mptcpd`, look at the `/etc/mptcpd/mptcpd.conf` config
+file, or disable the service if it is not needed. Make sure not to
+have both NetworkManager and `mptcpd` conflicting to configure the
+MPTCP endpoints.
 
 ## Installing `mptcpd`
 `mptcpd` is packaged in most major distributions:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ information (e.g. available remote addresses), available network
 interfaces, request new MPTCP subflows, handle requests for subflows,
 etc.
 
+By default, this daemon will load the `addr_adv` plugin, which will
+add MPTCP endpoints with the `subflow` flag ("client" mode) for the
+default in-kernel path-manager. Note that this is something
+[NetworkManager 1.40 or newer](https://networkmanager.dev/blog/networkmanager-1-40/#mptcp-support)
+does by default. Having several daemons configuring the MPTCP
+endpoints at the same time should be avoided. This daemon is usually
+recommended when NetworkManager 1.40 or newer is not available, or
+when advanced per-connection path management is needed, using the
+userspace path-manager and a custom made
+[plugin](https://github.com/multipath-tcp/mptcpd/wiki/Plugins) using
+the [C API](https://mptcpd.mptcp.dev/doc/html/).
+
 ## Installing `mptcpd`
 `mptcpd` is packaged in most major distributions:
 

--- a/mptcpd.dox
+++ b/mptcpd.dox
@@ -16,8 +16,20 @@
  * interfaces, request new MPTCP subflows, handle requests for
  * subflows, etc.
  *
+ * By default, this daemon will load the `addr_adv` plugin, which will
+ * add MPTCP endpoints with the `subflow` flag ("client" mode) for the
+ * default in-kernel path-manager. Note that this is something
+ * [NetworkManager 1.40 or newer](https://networkmanager.dev/blog/networkmanager-1-40/#mptcp-support)
+ * does by default. Having several daemons configuring the MPTCP
+ * endpoints at the same time should be avoided. This daemon is usually
+ * recommended when NetworkManager 1.40 or newer is not available, or
+ * when advanced per-connection path management is needed, using the
+ * userspace path-manager and a custom made
+ * [plugin](https://github.com/multipath-tcp/mptcpd/wiki/Plugins) using
+ * the C API that is described here.
+ *
  * @see Additional higher level documentation is available in the
- *      [`mptcpd` Wiki](https://github.com/multipath-tcp/mptcpd/wiki).
+ *      [`mptcpd` Wiki](https://github.com/multipath-tcp/mptcpd/wiki/Plugins).
  */
 
 /*

--- a/mptcpd.dox
+++ b/mptcpd.dox
@@ -28,6 +28,14 @@
  * [plugin](https://github.com/multipath-tcp/mptcpd/wiki/Plugins) using
  * the C API that is described here.
  *
+ * To change this behavior, with NetworkManager, look for the
+ * `connection.mptcp-flags` option in the
+ * [settings](https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html#nm-settings-nmcli.property.connection.mptcp-flags),
+ * while for `mptcpd`, look at the `/etc/mptcpd/mptcpd.conf` config
+ * file, or disable the service if it is not needed. Make sure not to
+ * have both NetworkManager and `mptcpd` conflicting to configure the
+ * MPTCP endpoints.
+ *
  * @see Additional higher level documentation is available in the
  *      [`mptcpd` Wiki](https://github.com/multipath-tcp/mptcpd/wiki/Plugins).
  */


### PR DESCRIPTION
Because for someone new, it might not be clear what it does.

The idea is also to modify the welcome page on mptcpd.mptcp.dev with the same description.

Note that I also modified the main [wiki](https://github.com/multipath-tcp/mptcpd/wiki) page with the same description.