### PR TITLE
musl compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,11 @@ AC_CHECK_FUNC([l_netlink_message_new_sized],
 LIBS=$mptcpd_save_libs
 
 # ---------------------------------------------------------------
+# Checks for header files.
+# ---------------------------------------------------------------
+AC_CHECK_HEADERS([error.h])
+
+# ---------------------------------------------------------------
 # Enable additional C compiler warnings.  We do this after all
 # Autoconf tests have been run since not all autoconf macros are
 # warning free.

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,13 @@ AC_DEFINE_UNQUOTED([MPTCPD_LOGGER],
                    [Log message destination.])
 AC_SUBST([mptcpd_logger],[$enable_logging])
 
+AH_TEMPLATE([MPTCPD_LOGGER_STDERR],
+            [Define to 1 if the stderr logger is used.])
+AS_IF([test "x$enable_logging" = "xstderr"],
+      [AC_DEFINE([MPTCPD_LOGGER_STDERR])
+       AC_MSG_NOTICE([default logger: stderr])],
+      [AC_MSG_NOTICE([custom logger: $enable_logging])])
+
 # Allow the user to choose support for either the upstream or
 # multipath-tcp.org kernel.
 AC_ARG_WITH([kernel],

--- a/include/mptcpd/private/sockaddr.h
+++ b/include/mptcpd/private/sockaddr.h
@@ -15,6 +15,7 @@
 #include <byteswap.h>
 
 #include <netinet/in.h>   // For in_addr_t.
+#include <linux/swab.h>   // For __constant_swab*.
 
 #include <mptcpd/export.h>
 
@@ -26,8 +27,8 @@
  */
 ///@{
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-# define MPTCPD_CONSTANT_HTONS(hs) __bswap_constant_16(hs)
-# define MPTCPD_CONSTANT_HTONL(hl) __bswap_constant_32(hl)
+# define MPTCPD_CONSTANT_HTONS(hs) __swab16(hs)
+# define MPTCPD_CONSTANT_HTONL(hl) __swab32(hl)
 #else
 // No need to swap bytes on big endian platforms.
 // host byte order == network byte order

--- a/scripts/check-permissions
+++ b/scripts/check-permissions
@@ -19,7 +19,7 @@ exit_status=0
 
 for p in $@; do
     # Access rights in human readable form (e.g. "drwxrwxr-x")
-    perms=`stat --dereference --format=%A $p`
+    perms=`stat -L -c %A $p`
 
     # The write mode for "others".
     other_write=`echo $perms | sed -e 's/.*\(.\).$/\1/'`

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -50,8 +50,13 @@
 // This should never occur!
 # error Problem configuring default log message destination.
 #endif
-/// Name of the default logging function determined at compile-time.
-#define MPTCPD_SET_LOG_FUNCTION MPTCPD_CONCAT(l_log_set_, MPTCPD_LOGGER)
+// Optimisation for C standard library not supporting the concat macros.
+#ifdef MPTCPD_LOGGER_STDERR
+# define MPTCPD_SET_LOG_FUNCTION l_log_set_stderr
+#else
+/// Name of the logging function determined at compile-time.
+# define MPTCPD_SET_LOG_FUNCTION MPTCPD_CONCAT(l_log_set_, MPTCPD_LOGGER)
+#endif
 
 /**
  * @brief Get the function that sets the log message destination.

--- a/src/mptcpize.c
+++ b/src/mptcpize.c
@@ -18,7 +18,6 @@
 #include <argp.h>
 #include <dlfcn.h>
 #include <errno.h>
-#include <error.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -27,6 +26,10 @@
 
 #ifdef HAVE_CONFIG_H
 # include <mptcpd/private/config.h>
+#endif
+
+#ifdef HAVE_ERROR_H
+# include <error.h>
 #endif
 
 #define SYSTEMD_ENV_VAR		"Environment="
@@ -54,6 +57,20 @@ static char doc[] =
         "\t                          above launcher.\n\n"
         "\tdisable <unit>            Update the systemd <unit>, removing\n"
         "\t                          the above launcher.\n";
+
+#ifndef HAVE_ERROR_H
+# define ERROR_HELPER(status, errnum, format, ...) do {		\
+	if (errnum) {						\
+		errno = errnum;					\
+		perror(format);					\
+	} else {						\
+		fprintf(stderr, format "%s", __VA_ARGS__);	\
+	}							\
+	if (status)						\
+		exit(status);					\
+   } while(0)
+# define error(...) ERROR_HELPER(__VA_ARGS__, "\n")
+#endif
 
 static struct argp const argp = { 0, 0, args_doc, doc, 0, 0, 0 };
 


### PR DESCRIPTION
Here are a few small patches needed to be able to compile mptcpd with musl, e.g. on AlpineLinux