### PR TITLE
github: coverage: back to Ubuntu 22.04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@ on: ["push", "pull_request"]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
'ubuntu-latest' is now following Ubuntu 24.04, which comes with LCOV 2.0.

That's great, but the autoconf-archive package in Ubuntu 24.04 doesn't support LCOV 2.0, a fix [1] is missing.

The simple solution not to block further development is to switch back to Ubuntu 22.04 for this workflow.

Link: https://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=commit;h=fc10ebf6185441fcd5e0c0a183fcb97497553594 [1]