### PR TITLE
github: use ell from repo by default 

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,13 +26,13 @@ jobs:
         git checkout 0.30
         ./bootstrap
         ./configure --prefix=/usr
-        sudo make install
+        sudo make -j$(nproc) install
     - name: bootstrap
       run: ./bootstrap
     - name: configure
       run: ./configure --${{ matrix.debug }}
     - name: make
-      run: make
+      run: make -j$(nproc)
     - name: make check
       run: make check
     - name: make distcheck

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,15 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
-      run: sudo apt-get -y install autoconf-archive pandoc git
-    - name: build and install ELL
-      run: |
-        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
-        cd ell
-        git checkout 0.30
-        ./bootstrap
-        ./configure --prefix=/usr
-        sudo make -j$(nproc) install
+      run: sudo apt-get -y install autoconf-archive pandoc git libell-dev
     - name: bootstrap
       run: ./bootstrap
     - name: configure

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,13 +18,13 @@ jobs:
         git checkout 0.30
         ./bootstrap
         ./configure --prefix=/usr
-        sudo make install
+        sudo make -j$(nproc) install
     - name: bootstrap
       run: ./bootstrap
     - name: configure
       run: ./configure --enable-code-coverage
     - name: make
-      run: make
+      run: make -j$(nproc)
     - name: make check
       run: make check-code-coverage \
              CODE_COVERAGE_OUTPUT_FILE=lcov.info \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,15 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
-      run: sudo apt-get -y install autoconf-archive lcov git
-    - name: build and install ELL
-      run: |
-        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
-        cd ell
-        git checkout 0.30
-        ./bootstrap
-        ./configure --prefix=/usr
-        sudo make -j$(nproc) install
+      run: sudo apt-get -y install autoconf-archive lcov git libell-dev
     - name: bootstrap
       run: ./bootstrap
     - name: configure

--- a/.github/workflows/ell-master.yml
+++ b/.github/workflows/ell-master.yml
@@ -28,12 +28,12 @@ jobs:
         git log -1 --oneline --no-decorate
         ./bootstrap
         ./configure CC=${{ matrix.cc }} --prefix=/usr
-        sudo make install
+        sudo make -j$(nproc) install
     - name: bootstrap
       run: ./bootstrap
     - name: configure
       run: ./configure CC=${{ matrix.cc }}
     - name: make
-      run: make
+      run: make -j$(nproc)
     - name: make check
       run: make check

--- a/.github/workflows/ell-min.yml
+++ b/.github/workflows/ell-min.yml
@@ -1,0 +1,37 @@
+name: ELL min version
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: dependencies
+      run: sudo apt-get -y install autoconf-archive git clang
+    - name: build and install ELL
+      run: |
+        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
+        cd ell
+        git checkout 0.30
+        ./bootstrap
+        ./configure CC=${{ matrix.cc }} --prefix=/usr
+        sudo make -j$(nproc) install
+    - name: bootstrap
+      run: ./bootstrap
+    - name: configure
+      run: ./configure CC=${{ matrix.cc }}
+    - name: make
+      run: make -j$(nproc)
+    - name: make check
+      run: make check

--- a/.github/workflows/multipath-tcp.org.yml
+++ b/.github/workflows/multipath-tcp.org.yml
@@ -22,10 +22,10 @@ jobs:
         git checkout 0.30
         ./bootstrap
         ./configure --prefix=/usr
-        sudo make install
+        sudo make -j$(nproc) install
     - name: bootstrap
       run: ./bootstrap
     - name: configure
       run: ./configure --with-kernel=multipath-tcp.org
     - name: make
-      run: make
+      run: make -j$(nproc)

--- a/.github/workflows/multipath-tcp.org.yml
+++ b/.github/workflows/multipath-tcp.org.yml
@@ -14,15 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: dependencies
-      run: sudo apt-get -y install autoconf-archive git
-    - name: build and install ELL
-      run: |
-        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
-        cd ell
-        git checkout 0.30
-        ./bootstrap
-        ./configure --prefix=/usr
-        sudo make -j$(nproc) install
+      run: sudo apt-get -y install autoconf-archive git libell-dev
     - name: bootstrap
       run: ./bootstrap
     - name: configure


### PR DESCRIPTION
Instead of compiling the min version all the time. Use a more "normal" setup.

While at it, use `-j`