### PR TITLE
github: check: print logs in case of errors

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -26,7 +26,7 @@ jobs:
     - name: make
       run: make -j$(nproc)
     - name: make check
-      run: make check
+      run: make check || { cat tests/test-suite.log; exit 1; }
     - name: make distcheck
       run: make distcheck
     - name: make install

--- a/.github/workflows/ell-master.yml
+++ b/.github/workflows/ell-master.yml
@@ -36,4 +36,4 @@ jobs:
     - name: make
       run: make -j$(nproc)
     - name: make check
-      run: make check
+      run: make check || { cat tests/test-suite.log; exit 1; }

--- a/.github/workflows/ell-min.yml
+++ b/.github/workflows/ell-min.yml
@@ -34,4 +34,4 @@ jobs:
     - name: make
       run: make -j$(nproc)
     - name: make check
-      run: make check
+      run: make check || { cat tests/test-suite.log; exit 1; }


### PR DESCRIPTION
Otherwise, only a vague error is printed:

     ../test-driver: line 112: 18416 Aborted (core dumped) "$@" >> "$log_file" 2>&1