### PR TITLE
sspi: fix typo

### DIFF
--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -609,7 +609,7 @@ static void sspi_connection_established(mptcpd_token_t token,
         (void) token;
         (void) laddr;
         (void) raddr;
-        (void) server_side,
+        (void) server_side;
         (void) pm;
 
         /**


### PR DESCRIPTION
It is not really an issue, but a semicolon was expected there, not a comma.

Originally from #323, but splitting to ease the reviews.