### PR TITLE
man: plugin-dir: not world writable

### DIFF
--- a/man/mptcpd.8.in
+++ b/man/mptcpd.8.in
@@ -118,7 +118,8 @@ related addresses are updated, e.g.
 .TP
 .BI \-\-plugin\-dir= DIR
 set plugin directory to
-.I DIR
+.IR DIR ,
+which should not be world writable for security reasons.
 
 .TP
 .BI \-\-path\-manager= PLUGIN


### PR DESCRIPTION
Small security note not to have a plugin directory in world writable.

Indeed, mptcpd is executed with extra permissions, and it will load plugins. Not everybody should then be able to add new plugins.