### PR TITLE
github: ell: clone from Google servers and retry

### DIFF
--- a/.github/workflows/ell-master.yml
+++ b/.github/workflows/ell-master.yml
@@ -23,7 +23,11 @@ jobs:
       run: sudo apt-get -y install autoconf-archive git clang
     - name: build and install ELL
       run: |
-        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
+        for i in $(seq 30); do
+          git clone https://kernel.googlesource.com/pub/scm/libs/ell/ell && break
+          echo "Attempt $i failed, retrying in 30 seconds..."
+          sleep 30
+        done
         cd ell
         git log -1 --oneline --no-decorate
         ./bootstrap

--- a/.github/workflows/ell-min.yml
+++ b/.github/workflows/ell-min.yml
@@ -21,7 +21,11 @@ jobs:
       run: sudo apt-get -y install autoconf-archive git clang
     - name: build and install ELL
       run: |
-        git clone git://git.kernel.org/pub/scm/libs/ell/ell.git
+        for i in $(seq 30); do
+          git clone https://kernel.googlesource.com/pub/scm/libs/ell/ell && break
+          echo "Attempt $i failed, retrying in 30 seconds..."
+          sleep 30
+        done
         cd ell
         git checkout 0.30
         ./bootstrap


### PR DESCRIPTION
Recently, we had two jobs in a row that failed to clone ELL repo. Probably because of the restrictions in place at git.kernel.org, and the fact two clone are being done in parallel, likely from the same IP range.

Switching to googlesource.com, which should be more tolerant, and retry max 30 times with a 30 seconds sleep in between.

If it is really not possible to clone the repo, the 'ell' dir will not be created.