### PR TITLE
flags: define "implicit"

### DIFF
--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -74,6 +74,16 @@ typedef uint32_t mptcpd_flags_t;
  */
 #define MPTCPD_ADDR_FLAG_FULLMESH (1U << 3)
 
+/**
+ * @brief Endpoint implicitly created by the kernel PM.
+ *
+ * It exists because no userspace ones correspond to the associated address
+ * and port. It can only be set by the kernel.
+ *
+ * @note Do not set from the userspace to the kernelspace.
+ */
+#define MPTCPD_ADDR_FLAG_IMPLICIT (1U << 4)
+
 /// Use this endpoint in reaction to ADD_ADDR, but only once.
 #define MPTCPD_ADDR_FLAG_LAMINAR (1U << 5)
 ///@}

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -35,6 +35,7 @@
         || MPTCPD_ADDR_FLAG_SUBFLOW != MPTCP_PM_ADDR_FLAG_SUBFLOW       \
         || MPTCPD_ADDR_FLAG_BACKUP != MPTCP_PM_ADDR_FLAG_BACKUP         \
         || MPTCPD_ADDR_FLAG_FULLMESH != MPTCP_PM_ADDR_FLAG_FULLMESH     \
+        || MPTCPD_ADDR_FLAG_IMPLICIT != MPTCP_PM_ADDR_FLAG_IMPLICIT     \
         || MPTCPD_ADDR_FLAG_LAMINAR != MPTCP_PM_ADDR_FLAG_LAMINAR
 # error Mismatch between mptcpd and upstream kernel addr flags.
 #endif


### PR DESCRIPTION
Mainly to add a comment about that: it cannot be set from the userspace, so it should not be used in path-managers.

Suggested-by: @sskras