### PR TITLE
plugin: expose subflow error to plugins

### DIFF
--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -247,6 +247,7 @@ struct mptcpd_plugin_ops
          * @param[in] laddr  Local address information.
          * @param[in] raddr  Remote address information.
          * @param[in] backup Backup priority flag.
+         * @param[in] error  Subflow related event error.
          * @param[in] pm     Opaque pointer to mptcpd path manager
          *                   object.
          */
@@ -254,6 +255,7 @@ struct mptcpd_plugin_ops
                                struct sockaddr const *laddr,
                                struct sockaddr const *raddr,
                                bool backup,
+                               uint8_t error,
                                struct mptcpd_pm *pm);
 
         /**

--- a/include/mptcpd/plugin.h
+++ b/include/mptcpd/plugin.h
@@ -247,7 +247,8 @@ struct mptcpd_plugin_ops
          * @param[in] laddr  Local address information.
          * @param[in] raddr  Remote address information.
          * @param[in] backup Backup priority flag.
-         * @param[in] error  Subflow related event error.
+         * @param[in] error  Subflow closing error, if any. The 'errno'
+         *                   set in 'sk_err', e.g. reset, timeout, etc.
          * @param[in] pm     Opaque pointer to mptcpd path manager
          *                   object.
          */

--- a/include/mptcpd/private/plugin.h
+++ b/include/mptcpd/private/plugin.h
@@ -147,6 +147,7 @@ MPTCPD_API void mptcpd_plugin_new_subflow(
  * @param[in] laddr  Local address information.
  * @param[in] raddr  Remote address information.
  * @param[in] backup Backup priority flag.
+ * @param[in] error  Subflow related event error.
  * @param[in] pm     Opaque pointer to mptcpd path manager object.
  */
 MPTCPD_API void mptcpd_plugin_subflow_closed(
@@ -154,6 +155,7 @@ MPTCPD_API void mptcpd_plugin_subflow_closed(
         struct sockaddr const *laddr,
         struct sockaddr const *raddr,
         bool backup,
+        uint8_t error,
         struct mptcpd_pm *pm);
 
 /**

--- a/include/mptcpd/private/plugin.h
+++ b/include/mptcpd/private/plugin.h
@@ -147,7 +147,8 @@ MPTCPD_API void mptcpd_plugin_new_subflow(
  * @param[in] laddr  Local address information.
  * @param[in] raddr  Remote address information.
  * @param[in] backup Backup priority flag.
- * @param[in] error  Subflow related event error.
+ * @param[in] error  Subflow closing error, if any. The 'errno'
+ *                   set in 'sk_err', e.g. reset, timeout, etc.
  * @param[in] pm     Opaque pointer to mptcpd path manager object.
  */
 MPTCPD_API void mptcpd_plugin_subflow_closed(

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -659,12 +659,13 @@ void mptcpd_plugin_subflow_closed(mptcpd_token_t token,
                                   struct sockaddr const *laddr,
                                   struct sockaddr const *raddr,
                                   bool backup,
+                                  uint8_t error,
                                   struct mptcpd_pm *pm)
 {
         struct mptcpd_plugin_ops const *const ops = token_to_ops(token);
 
         if (ops && ops->subflow_closed)
-                ops->subflow_closed(token, laddr, raddr, backup, pm);
+                ops->subflow_closed(token, laddr, raddr, backup, error, pm);
 
 }
 

--- a/plugins/path_managers/sspi.c
+++ b/plugins/path_managers/sspi.c
@@ -729,10 +729,12 @@ static void sspi_subflow_closed(mptcpd_token_t token,
                                 struct sockaddr const *laddr,
                                 struct sockaddr const *raddr,
                                 bool backup,
+                                uint8_t error,
                                 struct mptcpd_pm *pm)
 {
         (void) raddr;
         (void) backup;
+        (void) error;
 
         /*
           1. Retrieve the subflow list associated with the local

--- a/src/path_manager.c
+++ b/src/path_manager.c
@@ -518,6 +518,7 @@ static void handle_subflow_closed(struct pm_event_attrs const *attrs,
                                      (struct sockaddr *) &laddr,
                                      (struct sockaddr *) &raddr,
                                      attrs->backup,
+                                     attrs->error ? *attrs->error : 0,
                                      pm);
 }
 

--- a/tests/lib/call_plugin.c
+++ b/tests/lib/call_plugin.c
@@ -63,6 +63,7 @@ void call_plugin_ops(struct plugin_call_count const *count,
                                              args->laddr,
                                              args->raddr,
                                              args->backup,
+                                             args->error,
                                              args->pm);
 
         for (int i = 0; i < count->subflow_priority; ++i)

--- a/tests/lib/test-plugin.h
+++ b/tests/lib/test-plugin.h
@@ -152,6 +152,7 @@ static mptcpd_aid_t   const test_raddr_id_1    = 0x56;
 static bool           const test_backup_1      = true;
 static bool           const test_server_side_1 = true;
 static bool           const test_deny_join_id0_1 = true;
+static uint8_t        const test_error_1       = 0;
 
 
 static mptcpd_token_t const test_token_2       = 0x23456789;
@@ -160,6 +161,7 @@ static mptcpd_aid_t   const test_raddr_id_2    = 0x45;
 static bool           const test_backup_2      = false;
 static bool           const test_server_side_2 = true;
 static bool           const test_deny_join_id0_2 = true;
+static uint8_t        const test_error_2       = 0;
 
 static mptcpd_token_t const test_token_4       = 0x34567890;
 static mptcpd_aid_t   const test_laddr_id_4    = 0x90;
@@ -167,6 +169,7 @@ static mptcpd_aid_t   const test_raddr_id_4    = 0x01;
 static bool           const test_backup_4      = true;
 static bool           const test_server_side_4 = false;
 static bool           const test_deny_join_id0_4 = false;
+static uint8_t        const test_error_4       = 0;
 
 // For verifying that a plugin will not be dispatched.
 static mptcpd_token_t const test_bad_token  = 0xFFFFFFFF;
@@ -311,6 +314,9 @@ struct plugin_call_args
 
         /// Remote peer deny a MP_JOIN to the initial IP address and port
         bool deny_join_id0;
+
+        /// Subflow related event error.
+        uint8_t error;
 
         /// Mptcpd path manager object.
         struct mptcpd_pm *const pm;

--- a/tests/lib/test-plugin.h
+++ b/tests/lib/test-plugin.h
@@ -169,7 +169,7 @@ static mptcpd_aid_t   const test_raddr_id_4    = 0x01;
 static bool           const test_backup_4      = true;
 static bool           const test_server_side_4 = false;
 static bool           const test_deny_join_id0_4 = false;
-static uint8_t        const test_error_4       = 0;
+static uint8_t        const test_error_4       = 110;
 
 // For verifying that a plugin will not be dispatched.
 static mptcpd_token_t const test_bad_token  = 0xFFFFFFFF;

--- a/tests/plugins/noop/noop.c
+++ b/tests/plugins/noop/noop.c
@@ -91,12 +91,14 @@ static void plugin_noop_subflow_closed(mptcpd_token_t token,
                                        struct sockaddr const *laddr,
                                        struct sockaddr const *raddr,
                                        bool backup,
+                                       uint8_t error,
                                        struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
         (void) backup;
+        (void) error;
         (void) pm;
 }
 

--- a/tests/plugins/priority/one.c
+++ b/tests/plugins/priority/one.c
@@ -130,6 +130,7 @@ static void plugin_one_subflow_closed(mptcpd_token_t token,
                                       struct sockaddr const *laddr,
                                       struct sockaddr const *raddr,
                                       bool backup,
+                                      uint8_t error,
                                       struct mptcpd_pm *pm)
 {
         (void) pm;
@@ -138,6 +139,7 @@ static void plugin_one_subflow_closed(mptcpd_token_t token,
         assert(sockaddr_is_equal(laddr, local_addr));
         assert(sockaddr_is_equal(raddr, remote_addr));
         assert(backup == test_backup_1);
+        assert(error == test_error_1);
 
         ++call_count.subflow_closed;
 }

--- a/tests/plugins/priority/two.c
+++ b/tests/plugins/priority/two.c
@@ -131,6 +131,7 @@ static void plugin_two_subflow_closed(mptcpd_token_t token,
                                       struct sockaddr const *laddr,
                                       struct sockaddr const *raddr,
                                       bool backup,
+                                      uint8_t error,
                                       struct mptcpd_pm *pm)
 {
         (void) pm;
@@ -139,6 +140,7 @@ static void plugin_two_subflow_closed(mptcpd_token_t token,
         assert(sockaddr_is_equal(laddr, local_addr));
         assert(sockaddr_is_equal(raddr, remote_addr));
         assert(backup == test_backup_2);
+        assert(error == test_error_2);
 
         ++call_count.subflow_closed;
 }

--- a/tests/plugins/security/four.c
+++ b/tests/plugins/security/four.c
@@ -114,12 +114,14 @@ static void plugin_four_subflow_closed(mptcpd_token_t token,
                                         struct sockaddr const *laddr,
                                         struct sockaddr const *raddr,
                                         bool backup,
+                                        uint8_t error,
                                         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
         (void) backup;
+        (void) error;
         (void) pm;
 
         ++call_count.subflow_closed;

--- a/tests/plugins/security/three.c
+++ b/tests/plugins/security/three.c
@@ -114,12 +114,14 @@ static void plugin_three_subflow_closed(mptcpd_token_t token,
                                         struct sockaddr const *laddr,
                                         struct sockaddr const *raddr,
                                         bool backup,
+                                        uint8_t error,
                                         struct mptcpd_pm *pm)
 {
         (void) token;
         (void) laddr;
         (void) raddr;
         (void) backup;
+        (void) error;
         (void) pm;
 
         ++call_count.subflow_closed;

--- a/tests/test-plugin.c
+++ b/tests/test-plugin.c
@@ -52,7 +52,8 @@ static bool run_plugin_load(mode_t mode, struct l_queue const *queue)
                         .raddr       = (struct sockaddr const *) &test_raddr_4,
                         .backup      = test_backup_4,
                         .server_side = test_server_side_4,
-                        .deny_join_id0 = test_deny_join_id0_4
+                        .deny_join_id0 = test_deny_join_id0_4,
+                        .error       = test_error_4
                 };
 
                 call_plugin_ops(&test_count_4, &args);
@@ -216,7 +217,8 @@ static void test_plugin_dispatch(void const *test_data)
                 .raddr       = (struct sockaddr const *) &test_raddr_1,
                 .backup      = test_backup_1,
                 .server_side = test_server_side_1,
-                .deny_join_id0 = test_deny_join_id0_1
+                .deny_join_id0 = test_deny_join_id0_1,
+                .error       = test_error_1
         };
 
         call_plugin_ops(&test_count_1, &args1);
@@ -229,7 +231,8 @@ static void test_plugin_dispatch(void const *test_data)
                 .raddr       = args1.raddr,
                 .backup      = args1.backup,
                 .server_side = args1.server_side,
-                .deny_join_id0 = args1.deny_join_id0
+                .deny_join_id0 = args1.deny_join_id0,
+                .error       = args1.error
         };
 
         call_plugin_ops(&test_count_1, &args1_default);
@@ -243,7 +246,8 @@ static void test_plugin_dispatch(void const *test_data)
                 .raddr       = (struct sockaddr const *) &test_raddr_2,
                 .backup      = test_backup_2,
                 .server_side = test_server_side_2,
-                .deny_join_id0 = test_deny_join_id0_2
+                .deny_join_id0 = test_deny_join_id0_2,
+                .error       = test_error_2
         };
 
         call_plugin_ops(&test_count_2, &args2);
@@ -306,6 +310,7 @@ static void test_null_plugin_ops(void const *test_data)
         static bool backup = false;
         static bool server_side = false;
         static bool deny_join_id0 = false;
+        static uint8_t error = 0;
         static struct mptcpd_interface const *const interface = NULL;
 
         // No dispatch should occur in the following calls.
@@ -317,7 +322,7 @@ static void test_null_plugin_ops(void const *test_data)
         mptcpd_plugin_new_address(token, id, raddr, pm);
         mptcpd_plugin_address_removed(token, id, pm);
         mptcpd_plugin_new_subflow(token, laddr, raddr, backup, pm);
-        mptcpd_plugin_subflow_closed(token, laddr, raddr, backup, pm);
+        mptcpd_plugin_subflow_closed(token, laddr, raddr, backup, error, pm);
         mptcpd_plugin_subflow_priority(token, laddr, raddr, backup, pm);
         mptcpd_plugin_listener_created(name, laddr, pm);
         mptcpd_plugin_listener_closed(name, laddr, pm);


### PR DESCRIPTION
Add error parameter to subflow_closed callback to allow plugins to identify the reason for subflow closure, such as network errors.

The error value corresponds to the `MPTCP_ATTR_ERROR` attribute from the kernel, which equals `sk_err` from `struct sock`. If the error attribute is not present in the Netlink message, it defaults to 0.

Fixes #330

## Changes
- Updated `mptcpd_plugin_ops.subflow_closed` signature to include `uint8_t error` parameter
- Modified all plugins and tests to use the new signature
- Added test validation for the error parameter
