### PR TITLE
Prepare 0.14 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Davide Caratti <davide.caratti@gmail.com>
 Daniel Danzberger <d.danzberger@ddf-software.de>
 João Meira <dulive.misc@protonmail.com>
 Matthieu Baerts <matttbe@kernel.org>
+marco-a-itl <marco.angaroni@italtel.com>

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,33 @@
+17 December 2025 - mptcpd 0.14
+
+- libmptcpd breaking changes:
+
+  - 'new_connection' and 'connection_established' interfaces have a new
+     parameter: deny_join_id0. It is set when the other peer requested
+     not to create new subflows to the initial IP address and port.
+     See: https://www.mptcp.dev/load-balancer.html
+
+  - 'subflow_closed' interface has a new 'error' parameter, set to a
+    non-zero errno value if the subflow has been closed due to an error
+    like a reset, a timeout, etc.
+
+- Add support for the new 'laminar' in-kernel PM endpoint, see:
+  https://www.mptcp.dev/pm.html
+
+- mptcpize: LD_PRELOAD is now appended, not overridden.
+
+- mptcpize: GODEBUG=multipathtcp=1 environment variable is also set.
+  GODEBUG is appended if it is already defined.
+
+- mptcpd now support ELL 0.72: a recent API change broke mptcpd
+  'commands' test.
+
+- Add musl libc compatibility. Note that the unit tests still require
+  GLibC.
+
+- A recommendation has been added not to have a plugin directory with
+  world writeable permissions for security reasons.
+
 3 November 2024 - mptcpd 0.13
 
 - mptcpd now supports ELL 0.68.

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([mptcpd],
-        [0.13],
+        [0.14],
         [mptcp@lists.linux.dev],
         [],
         [https://github.com/multipath-tcp/mptcpd])


### PR DESCRIPTION
I suggest creating a new v0.14 release.

The 4 first steps from [New version's TODO list](https://github.com/multipath-tcp/mptcpd/wiki/Maintainers#new-versions-todo-list) have been done so far.