### PR TITLE
UserPM: Implement per-token get_addr/dump_addrs for userspace path manager

### DIFF
--- a/include/mptcpd/path_manager.h
+++ b/include/mptcpd/path_manager.h
@@ -232,6 +232,49 @@ MPTCPD_API int mptcpd_pm_remove_subflow(
         mptcpd_token_t token,
         struct sockaddr const *local_addr,
         struct sockaddr const *remote_addr);
+
+/**
+ * @brief Get network address corresponding to an address ID.
+ *
+ * @param[in] pm       The mptcpd path manager object.
+ * @param[in] token    MPTCP connection token.
+ * @param[in] id       MPTCP local address ID.
+ * @param[in] callback Function to be called when the network address
+ *                     corresponding to the given MPTCP address @a id
+ *                     has been retrieved.
+ * @param[in] data     Data to be passed to the @a callback function.
+ * @param[in] complete Function called when the asynchronous
+ *                     @c get_addr call completes.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_pm_get_addr(struct mptcpd_pm *pm,
+                                  mptcpd_token_t token,
+                                  mptcpd_aid_t id,
+                                  mptcpd_pm_get_addr_cb_t callback,
+                                  void *data,
+                                  mptcpd_complete_func_t complete);
+
+/**
+ * @brief Get list of MPTCP network addresses for a connection.
+ *
+ * @param[in] pm       The mptcpd path manager object.
+ * @param[in] token    MPTCP connection token.
+ * @param[in] callback Function to be called when a network address
+ *                     has been retrieved.  This function will be
+ *                     called when each address dump is available, or
+ *                     possibly not at all.
+ * @param[in] data     Data to be passed to the @a callback function.
+ * @param[in] complete Function called when the asynchronous
+ *                     @c dump_addrs call completes.
+ *
+ * @return @c 0 if operation was successful. -1 or @c errno otherwise.
+ */
+MPTCPD_API int mptcpd_pm_dump_addrs(struct mptcpd_pm *pm,
+                                    mptcpd_token_t token,
+                                    mptcpd_pm_get_addr_cb_t callback,
+                                    void *data,
+                                    mptcpd_complete_func_t complete);
 ///@}
 
 /**

--- a/include/mptcpd/private/path_manager.h
+++ b/include/mptcpd/private/path_manager.h
@@ -248,6 +248,54 @@ struct mptcpd_pm_cmd_ops
                           struct sockaddr const *local_addr,
                           struct sockaddr const *remote_addr,
                           bool backup);
+
+        /**
+         * @brief Get network address corresponding to an address ID.
+         *
+         * @param[in] pm       The mptcpd path manager object.
+         * @param[in] token    MPTCP connection token.
+         * @param[in] id       MPTCP local address ID.
+         * @param[in] callback Function to be called when the network
+         *                     address corresponding to the given
+         *                     MPTCP address @a id has been retrieved.
+         * @param[in] data     Data to be passed to the @a callback
+         *                     function.
+         * @param[in] complete Function called when the asynchronous
+         *                     @c get_addr call completes.
+         *
+         * @return @c 0 if operation was successful. -1 or @c errno
+         *         otherwise.
+         */
+        int (*get_addr)(struct mptcpd_pm *pm,
+                        mptcpd_token_t token,
+                        mptcpd_aid_t id,
+                        mptcpd_pm_get_addr_cb_t callback,
+                        void *data,
+                        mptcpd_complete_func_t complete);
+
+        /**
+         * @brief Dump list of network addresses for a connection.
+         *
+         * @param[in] pm       The mptcpd path manager object.
+         * @param[in] token    MPTCP connection token.
+         * @param[in] callback Function to be called when a dump of
+         *                     network addresses has been retrieved.
+         *                     This function will be called when each
+         *                     address dump is available, or possibly
+         *                     not at all.
+         * @param[in] data     Data to be passed to the @a callback
+         *                     function.
+         * @param[in] complete Function called when the asynchronous
+         *                     @c dump_addrs call completes.
+         *
+         * @return @c 0 if operation was successful. -1 or @c errno
+         *         otherwise.
+         */
+        int (*dump_addrs)(struct mptcpd_pm *pm,
+                          mptcpd_token_t token,
+                          mptcpd_pm_get_addr_cb_t callback,
+                          void *data,
+                          mptcpd_complete_func_t complete);
 };
 
 /**

--- a/include/mptcpd/types.h
+++ b/include/mptcpd/types.h
@@ -136,6 +136,24 @@ typedef void (*mptcpd_kpm_get_addr_cb_t)(
         void *callback_data);
 
 /**
+ * @brief Type of function called when a userspace PM address is
+ *        available.
+ *
+ * The mptcpd path manager will call a function of this type when the
+ * result of calling @c mptcpd_pm_get_addr() or
+ * @c mptcpd_pm_dump_addrs() is available.
+ *
+ * @param[in]     info          Network address information.  @c NULL
+ *                              on error.
+ * @param[in,out] callback_data Data provided by the caller of
+ *                              @c mptcpd_pm_get_addr() or
+ *                              @c mptcpd_pm_dump_addrs().
+ */
+typedef void (*mptcpd_pm_get_addr_cb_t)(
+        struct mptcpd_addr_info const *info,
+        void *callback_data);
+
+/**
  * @brief Type of function called on asynchronous call completion.
  *
  * The mptcpd path manager API has several functions that complete

--- a/lib/path_manager.c
+++ b/lib/path_manager.c
@@ -370,6 +370,49 @@ int mptcpd_pm_remove_subflow(struct mptcpd_pm *pm,
                                    remote_addr);
 }
 
+int mptcpd_pm_get_addr(struct mptcpd_pm *pm,
+                       mptcpd_token_t token,
+                       mptcpd_aid_t id,
+                       mptcpd_pm_get_addr_cb_t callback,
+                       void *data,
+                       mptcpd_complete_func_t complete)
+{
+        if (pm == NULL || token == 0 || id == 0 || callback == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_pm_cmd_ops const *const ops =
+                pm->netlink_pm->cmd_ops;
+
+        if (ops == NULL || ops->get_addr == NULL)
+                return ENOTSUP;
+
+        return ops->get_addr(pm, token, id, callback, data, complete);
+}
+
+int mptcpd_pm_dump_addrs(struct mptcpd_pm *pm,
+                         mptcpd_token_t token,
+                         mptcpd_pm_get_addr_cb_t callback,
+                         void *data,
+                         mptcpd_complete_func_t complete)
+{
+        if (pm == NULL || token == 0 || callback == NULL)
+                return EINVAL;
+
+        if (!is_pm_ready(pm, __func__))
+                return EAGAIN;
+
+        struct mptcpd_pm_cmd_ops const *const ops =
+                pm->netlink_pm->cmd_ops;
+
+        if (ops == NULL || ops->dump_addrs == NULL)
+                return ENOTSUP;
+
+        return ops->dump_addrs(pm, token, callback, data, complete);
+}
+
 // -------------------------------------------------------------------
 
 struct mptcpd_nm const * mptcpd_pm_get_nm(struct mptcpd_pm const *pm)

--- a/src/netlink_pm_upstream.c
+++ b/src/netlink_pm_upstream.c
@@ -552,14 +552,27 @@ static int upstream_set_backup(struct mptcpd_pm *pm,
 /**
  * @struct get_addr_user_callback
  *
- * @brief Convenience struct for passing addr to user callback.
+ * @brief Convenience struct for passing addr to a get_addr/dump_addrs
+ *        user callback.
+ *
+ * @note Shared by the in-kernel (@c mptcpd_kpm_get_addr /
+ *       @c mptcpd_kpm_dump_addrs) and userspace
+ *       (@c mptcpd_pm_get_addr / @c mptcpd_pm_dump_addrs) path manager
+ *       implementations.  Both use the same result callback signature,
+ *       so a single wrapper type (and a single set of genl reply/free
+ *       callbacks) covers both.
  */
 struct get_addr_user_callback
 {
-        /// User supplied get_addr/dump_addrs callback.
-        mptcpd_kpm_get_addr_cb_t get_addr;
+        /**
+         * User supplied get_addr/dump_addrs result callback.  Stored as
+         * a generic function pointer so this struct is independent of
+         * the public typedef name (which differs between the in-kernel
+         * and userspace PM APIs); it is cast back when invoked.
+         */
+        void (*get_addr)(struct mptcpd_addr_info const *info, void *data);
 
-        /// User data to be passed to one of the above callback.
+        /// User data to be passed to the above callback.
         void *data;
 
         /**
@@ -940,7 +953,8 @@ static int upstream_get_addr(struct mptcpd_pm *pm,
         struct get_addr_user_callback *const cb =
                 l_new(struct get_addr_user_callback, 1);
 
-        cb->get_addr = callback;
+        cb->get_addr = (void (*)(struct mptcpd_addr_info const *,
+                                 void *)) callback;
         cb->data     = data;
         cb->complete = complete;
         cb->dump     = false;
@@ -969,7 +983,108 @@ static int upstream_dump_addrs(struct mptcpd_pm *pm,
         struct get_addr_user_callback *const cb =
                 l_new(struct get_addr_user_callback, 1);
 
-        cb->get_addr = callback;
+        cb->get_addr = (void (*)(struct mptcpd_addr_info const *,
+                                 void *)) callback;
+        cb->data     = data;
+        cb->complete = complete;
+        cb->dump     = true;
+
+        return l_genl_family_dump(
+                pm->family,
+                msg,
+                get_addr_callback,
+                cb,     /* user data */
+                get_addr_user_callback_free  /* destroy */) == 0;
+}
+
+static int upstream_pm_get_addr(struct mptcpd_pm *pm,
+                                mptcpd_token_t token,
+                                mptcpd_aid_t address_id,
+                                mptcpd_pm_get_addr_cb_t callback,
+                                void *data,
+                                mptcpd_complete_func_t complete)
+{
+        /*
+          Payload (nested):
+              Local address ID
+              Token
+         */
+
+        size_t const payload_size =
+                MPTCPD_NLA_ALIGN(address_id)
+                + MPTCPD_NLA_ALIGN(token);
+
+        struct l_genl_msg *const msg =
+                l_genl_msg_new_sized(MPTCP_PM_CMD_GET_ADDR,
+                                     payload_size);
+
+        bool const appended =
+                l_genl_msg_enter_nested(msg,
+                                        NLA_F_NESTED | MPTCP_PM_ATTR_ADDR)
+                && l_genl_msg_append_attr(msg,
+                                          MPTCP_PM_ADDR_ATTR_ID,
+                                          sizeof(address_id),
+                                          &address_id)
+                && l_genl_msg_leave_nested(msg)
+                && l_genl_msg_append_attr(msg,
+                                          MPTCP_PM_ATTR_TOKEN,
+                                          sizeof(token),
+                                          &token);
+
+        if (!appended) {
+                l_genl_msg_unref(msg);
+
+                return ENOMEM;
+        }
+
+        struct get_addr_user_callback *const cb =
+                l_new(struct get_addr_user_callback, 1);
+
+        cb->get_addr = (void (*)(struct mptcpd_addr_info const *,
+                                 void *)) callback;
+        cb->data     = data;
+        cb->complete = complete;
+        cb->dump     = false;
+
+        return l_genl_family_send(
+                pm->family,
+                msg,
+                get_addr_callback,
+                cb,     /* user data */
+                get_addr_user_callback_free  /* destroy */) == 0;
+}
+
+static int upstream_pm_dump_addrs(struct mptcpd_pm *pm,
+                                  mptcpd_token_t token,
+                                  mptcpd_pm_get_addr_cb_t callback,
+                                  void *data,
+                                  mptcpd_complete_func_t complete)
+{
+        /*
+          Payload:
+              Token
+         */
+
+        size_t const payload_size = MPTCPD_NLA_ALIGN(token);
+
+        struct l_genl_msg *const msg =
+                l_genl_msg_new_sized(MPTCP_PM_CMD_GET_ADDR,
+                                     payload_size);
+
+        if (!l_genl_msg_append_attr(msg,
+                                     MPTCP_PM_ATTR_TOKEN,
+                                     sizeof(token),
+                                     &token)) {
+                l_genl_msg_unref(msg);
+
+                return ENOMEM;
+        }
+
+        struct get_addr_user_callback *const cb =
+                l_new(struct get_addr_user_callback, 1);
+
+        cb->get_addr = (void (*)(struct mptcpd_addr_info const *,
+                                 void *)) callback;
         cb->data     = data;
         cb->complete = complete;
         cb->dump     = true;
@@ -1122,6 +1237,8 @@ static struct mptcpd_pm_cmd_ops const cmd_ops =
         .add_subflow    = upstream_add_subflow,
         .remove_subflow = upstream_remove_subflow,
         .set_backup     = upstream_set_backup,
+        .get_addr       = upstream_pm_get_addr,
+        .dump_addrs     = upstream_pm_dump_addrs,
 };
 
 static struct mptcpd_kpm_cmd_ops const kcmd_ops =

--- a/tests/test-commands.c
+++ b/tests/test-commands.c
@@ -544,6 +544,64 @@ void test_remove_subflow(void const *test_data)
         assert(result == 0 || result == ENOTSUP);
 }
 
+// -----------------------------------------------------------------------
+// User space (client-oriented) path manager address query commands.
+// -----------------------------------------------------------------------
+
+/*
+  Reply callback for the userspace PM get_addr/dump_addrs tests.
+
+  The query is keyed by the connection token, and the token used below
+  (u_addr->token) does not correspond to a real MPTCP connection, so the
+  kernel returns no address and this callback is not expected to be
+  invoked.  It is provided to exercise the reply path without crashing
+  should the kernel return a result.
+*/
+static void pm_get_addr_cb(struct mptcpd_addr_info const *info,
+                           void *user_data)
+{
+        (void) user_data;
+
+        if (info != NULL)
+                l_info("userspace PM addr query: id=%u",
+                       mptcpd_addr_info_get_id(info));
+}
+
+static void test_get_addr_user(void const *test_data)
+{
+        struct test_info  *const info = (struct test_info *) test_data;
+        struct mptcpd_pm  *const pm   = info->pm;
+
+        struct test_addr_info const *const u_addr = &info->u_addr;
+
+        int const result =
+                mptcpd_pm_get_addr(pm,
+                                   u_addr->token,
+                                   u_addr->id,
+                                   pm_get_addr_cb,
+                                   info,
+                                   NULL);
+
+        assert(result == 0 || result == ENOTSUP);
+}
+
+static void test_dump_addrs_user(void const *test_data)
+{
+        struct test_info  *const info = (struct test_info *) test_data;
+        struct mptcpd_pm  *const pm   = info->pm;
+
+        struct test_addr_info const *const u_addr = &info->u_addr;
+
+        int const result =
+                mptcpd_pm_dump_addrs(pm,
+                                     u_addr->token,
+                                     pm_get_addr_cb,
+                                     info,
+                                     NULL);
+
+        assert(result == 0 || result == ENOTSUP);
+}
+
 // -------------------------------------------------------------------
 
 
@@ -645,6 +703,8 @@ static void exec_tests(void *user_data)
         test_add("set_backup",         test_set_backup,       info);
         test_add("remove_subflow",     test_remove_subflow,   info);
         test_add("remove_addr - user", test_remove_addr_user, info);
+        test_add("get_addr - user",    test_get_addr_user,    info);
+        test_add("dump_addrs - user",  test_dump_addrs_user,  info);
 }
 
 static void run_tests(void *user_data)


### PR DESCRIPTION
Hi @matttbe 

This patch series implements per-connection token-based address query APIs (mptcpd_pm_get_addr() / mptcpd_pm_dump_addrs()) for the userspace MPTCP path manager, mirroring the existing in-kernel PM address query interfaces but isolated for per-connection token semantics.

It provides standardized per-connection address query interfaces exclusively for userspace PM plugins, facilitating real-time path status inspection, exception locating and function verification in custom PM development.

Co-developed-by: Geliang Tang [geliang@kernel.org](mailto:geliang@kernel.org)
Signed-off-by: Gang Yan [yangang@kylinos.cn](mailto:yangang@kylinos.cn)